### PR TITLE
Child search

### DIFF
--- a/snippets/get_docs.py
+++ b/snippets/get_docs.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import urllib
 import pathlib
 sys.path.append(f"{pathlib.Path(__file__).resolve().parent.parent}")
 
@@ -20,17 +21,48 @@ if __name__ == "__main__":
     )
 
     company = connection.__companies__.find(identifier="DataPull")
-    project = connection.__projects__.find(company_id=company["id"], identifier="R&D Test Project")
+    project = connection.__projects__.find(
+        company_id=company["id"],
+        identifier="R&D Test Project"
+    )
 
+    # Example 1: Get all folders
+    # ---------
+    print("Example 1")
     folders = connection.__folders__.get(
         company_id=company["id"],
         project_id=project["id"]
     )
+    print(folders)
 
+    # Example 2: Get all files
+    # ---------
+    print("\nExample 2")
     files = connection.__files__.get(
         company_id=company["id"],
         project_id=project["id"]
     )
+    print(files)
     
     print("Number of folders:", len(folders))
     print("Number of files:", len(files))
+
+    # Example 3: Get all children folders from parent
+    # ---------
+    print("\nExample 3")
+    subfolders = connection.__folders__.get(
+        company_id=company["id"],
+        project_id=project["id"],
+        folder_id=10857735
+    )
+    print(subfolders)
+
+    # Example 4: Get all children files from parent
+    # ---------
+    print("\nExample 4")
+    subfiles = connection.__files__.get(
+        company_id=company["id"],
+        project_id=project["id"],
+        folder_id=10857734
+    )
+    print(subfiles)

--- a/snippets/search_file.py
+++ b/snippets/search_file.py
@@ -45,6 +45,7 @@ if __name__ == "__main__":
 
     # Example 3: Find folder 
     # ---------
+    print("\nExample 3")
     doc3 = connection.__folders__.search(
         company_id=company["id"],
         project_id=project["id"],
@@ -53,3 +54,18 @@ if __name__ == "__main__":
     print(doc3)
     # {'id': 10857734, 'created_at': '2022-10-25T13:47:34Z', 'created_by': {'id': 93688, 'company_name': "Rogers O'Brien Construction", 'locale': None, 'login': 'hfritz@r-o.com', 'name': 'Hagen Fritz'}, 'custom_fields': {}, 'document_type': 'folder', 'is_deleted': False, 'is_recycle_bin': False, 'name': 'I-Safety and Environmental', 'name_with_path': 'R&D Test Project/I-Safety and Environmental', 'parent_id': 10857730, 'private': False, 'read_only': False, 'updated_at': '2022-10-25T13:47:34Z', 'search_critera': {'value': 'safety', 'match': 83}} 
     
+    # Example 4: Find subfolders in specified folder 
+    # ---------
+    print("\nExample 4")
+    folder = connection.__folders__.find(
+        company_id=company["id"],
+        project_id=project["id"],
+        identifier="I-Safety and Environmental"
+    )
+    doc4 = connection.__folders__.search(
+        company_id=company["id"],
+        project_id=project["id"],
+        folder_id=folder["id"],
+        value="subcontractor"
+    )
+    print(doc4)


### PR DESCRIPTION
This pull request (PR) resolves #24 

### Primary Changes
* 🔍 **Search from specified parent**: You can now specify a `folder_id` in the `Documents.search()` method which allows you to start at a specified location rather than search through the entire tree. 

### Related Changes
* ➰ **Loop through all project pages**: This change is what sovles #24 . Although we don't have _that_ many projects, we still loop through all possible pages just in case:
```python
projects = []
n_projects = 1
page = 1
while n_projects > 0:
    params = {
        "company_id": company_id,
        "page": page,
        "per_page": per_page
    }
    
    projects_per_page = self.get_request(
        api_url=self.endpoint,
        params=params
    )
    n_projects = len(projects_per_page)

    projects += projects_per_page

    page += 1

return projects
```