### PR TITLE
bugfix: check for 403 status on create

### DIFF
--- a/propycore/access/documents.py
+++ b/propycore/access/documents.py
@@ -7,7 +7,7 @@ from warnings import warn
 
 from fuzzywuzzy import fuzz
 
-from propycore.exceptions import NotFoundItemError, WrongParamsError, ProcoreException
+from propycore.exceptions import NotFoundItemError, WrongParamsError, ProcoreException, NoPrivilegeError
 
 class Documents(Base):
     """
@@ -299,8 +299,11 @@ class Folders(Documents):
                 additional_headers=headers,
                 data=data
             )
-        except ProcoreException:
-            raise WrongParamsError(f"Folder {folder_name} already exists")
+        except ProcoreException as e:
+            if "403" in e:
+                raise NoPrivilegeError(f"Data connection app or permission template does not allow creation of folders")
+            else:
+                raise WrongParamsError(f"Folder {folder_name} already exists")
         
         return doc_info
         
@@ -454,8 +457,11 @@ class Files(Documents):
                 data=data,
                 files=file
             )
-        except ProcoreException:
-            raise WrongParamsError(f"File {filename} already exists")
+        except ProcoreException as e:
+            if "403" in e:
+                raise NoPrivilegeError(f"Data connection app or permission template does not allow creation of files")
+            else:
+                raise WrongParamsError(f"File {filename} already exists")
         
         return doc_info
 

--- a/propycore/access/generic_tools.py
+++ b/propycore/access/generic_tools.py
@@ -4,7 +4,7 @@ import sys
 import pathlib
 sys.path.append(f"{pathlib.Path(__file__).resolve().parent.parent}")
 
-from propycore.exceptions import NotFoundItemError
+from propycore.exceptions import NotFoundItemError, NoPrivilegeError, WrongParamsError
 
 from exceptions import *
 
@@ -161,7 +161,10 @@ class GenericTool(Base):
                 data=data
             )
         except ProcoreException as e:
-            raise WrongParamsError(e)
+            if "403" in e:
+                raise NoPrivilegeError(f"Data connection app or permission template does not allow creation of generic tools")
+            else:
+                raise WrongParamsError(e)
         
         return item_info
     


### PR DESCRIPTION
### Primary Changes
* ⚠️ **Catch 403 Error on Create**: Only `documents` and `generic_tools` have create functions, but we needed to include a check for 403: forbidden errors in case the app doesn't have sufficient privileges